### PR TITLE
ci: Exclude tests in deno.json to prevent deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,4 @@ jobs:
           project: "pub-sub"
           entrypoint: "main.ts"
           root: "."
+          exclude: "**/*_test.ts"

--- a/deno.json
+++ b/deno.json
@@ -7,7 +7,7 @@
     "update": "deno run -A -r jsr:@fresh/update ."
   },
   "lint": { "rules": { "tags": ["fresh", "recommended"] } },
-  "exclude": ["**/_fresh/*"],
+  "exclude": ["**/_fresh/*", "**/*_test.ts"],
   "imports": {
     "@fresh/plugin-tailwind": "jsr:@fresh/plugin-tailwind@^1.0.0",
     "@fresh/plugin-vite": "jsr:@fresh/plugin-vite@1.0.8",

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,5 +1,4 @@
 import { decodeBase64Url, encodeBase64Url } from "@std/encoding/base64url";
-import { assertEquals } from "@std/assert";
 
 export type Pair = { topicId: string; secret: string };
 export async function generate(
@@ -43,7 +42,7 @@ const algorithm = {
   hash: { name: "SHA-512" },
   length: 256,
 };
-async function generateHmacKey() {
+export async function generateHmacKey() {
   const key = await crypto.subtle.generateKey(
     algorithm,
     true,
@@ -71,22 +70,3 @@ if (import.meta.main) {
   const key = await generateHmacKey();
   console.log(`HMAC_KEY=${key}`);
 }
-
-Deno.test("crypto", async () => {
-  const keyStr = await generateHmacKey();
-  const pair = await generate(keyStr);
-  const verified = await verify(pair, keyStr);
-  assertEquals(verified, "writable");
-
-  const pair2 = { topicId: pair.topicId + "a", secret: pair.secret };
-  const verified2 = await verify(pair2, keyStr);
-  assertEquals(verified2, "invalid");
-
-  const pair3 = { topicId: pair.topicId, secret: pair.secret + "&" };
-  const verified3 = await verify(pair3, keyStr);
-  assertEquals(verified3, "invalid");
-
-  const pair4 = { topicId: pair.topicId, secret: "" };
-  const verified4 = await verify(pair4, keyStr);
-  assertEquals(verified4, "readable");
-});

--- a/lib/crypto_test.ts
+++ b/lib/crypto_test.ts
@@ -1,0 +1,66 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { generate, generateHmacKey, verify } from "./crypto.ts";
+
+Deno.test("crypto operations", async (t) => {
+  const keyStr = await generateHmacKey();
+  const pair = await generate(keyStr);
+
+  await t.step("verify valid pair returns writable", async () => {
+    const verified = await verify(pair, keyStr);
+    assertEquals(verified, "writable");
+  });
+
+  await t.step("verify tampered topicId returns invalid", async () => {
+    const pair2 = { topicId: pair.topicId + "a", secret: pair.secret };
+    const verified2 = await verify(pair2, keyStr);
+    assertEquals(verified2, "invalid");
+  });
+
+  await t.step("verify tampered secret returns invalid", async () => {
+    const pair3 = { topicId: pair.topicId, secret: pair.secret + "&" };
+    const verified3 = await verify(pair3, keyStr);
+    assertEquals(verified3, "invalid");
+  });
+
+  await t.step("verify empty secret returns readable", async () => {
+    const pair4 = { topicId: pair.topicId, secret: "" };
+    const verified4 = await verify(pair4, keyStr);
+    assertEquals(verified4, "readable");
+  });
+
+  await t.step("verify invalid base64 returns invalid", async () => {
+    const invalidPair = { topicId: "invalid%", secret: "secret" };
+    const verified = await verify(invalidPair, keyStr);
+    assertEquals(verified, "invalid");
+  });
+});
+
+Deno.test("crypto - missing HMAC_KEY environment variable", async () => {
+  const originalKey = Deno.env.get("HMAC_KEY");
+  Deno.env.delete("HMAC_KEY");
+
+  try {
+    await assertRejects(
+      async () => {
+        await generate();
+      },
+      Error,
+      "HMAC_KEY not set",
+    );
+
+    await assertRejects(
+      async () => {
+        // Use valid base64 strings to pass the decoding check
+        // "dGVzdA" is "test" in base64url (no padding needed usually)
+        const pair = { topicId: "dGVzdA", secret: "dGVzdA" };
+        await verify(pair);
+      },
+      Error,
+      "HMAC_KEY not set",
+    );
+  } finally {
+    if (originalKey) {
+      Deno.env.set("HMAC_KEY", originalKey);
+    }
+  }
+});


### PR DESCRIPTION
Adding `**/*_test.ts` to the `exclude` list in `deno.json` ensures that `deno check` and other tools (including `deployctl`) do not attempt to process test files during deployment, preventing `ISOLATE_INTERNAL_FAILURE`.